### PR TITLE
Add `generate_oauth_token` function 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^\.httr-oauth$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,4 +11,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 URL: https://jdhoffa.github.io/wakastudio/
 Imports: 
-    httr
+    httr2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,5 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 URL: https://jdhoffa.github.io/wakastudio/
+Imports: 
+    httr

--- a/R/generate_oauth_token.R
+++ b/R/generate_oauth_token.R
@@ -1,0 +1,24 @@
+#' Generate a token for the WakaTime API
+#'
+#' @param app_id The app id for the WakaTime API
+#' @param app_secret The app secret for the WakaTime API
+#'
+#' @return An OAuth token
+#'
+#' @examples
+generate_oauth_token <- function(app_id = Sys.getenv("WAKATIME_ID"),
+                      app_secret = Sys.getenv("WAKATIME_SECRET")) {
+  httr::oauth2.0_token(
+    endpoint = httr::oauth_endpoint(
+      access = "https://wakatime.com/oauth/token",
+      authorize = "https://wakatime.com/oauth/authorize",
+      base_url = "https://api.wakatime.com/api/v1"
+    ),
+    app = httr::oauth_app(
+      appname = "wakastudio",
+      key = app_id,
+      secret = app_secret
+    ),
+    scope = "read_stats"
+  )
+}

--- a/R/generate_oauth_token.R
+++ b/R/generate_oauth_token.R
@@ -1,24 +1,35 @@
 #' Generate a token for the WakaTime API
 #'
-#' @param app_id The app id for the WakaTime API
-#' @param app_secret The app secret for the WakaTime API
+#' @param client_id The app id for the WakaTime API
+#' @param client_secret The app secret for the WakaTime API
 #'
 #' @return An OAuth token
 #'
 #' @examples
-generate_oauth_token <- function(app_id = Sys.getenv("WAKATIME_ID"),
-                      app_secret = Sys.getenv("WAKATIME_SECRET")) {
-  httr::oauth2.0_token(
-    endpoint = httr::oauth_endpoint(
-      access = "https://wakatime.com/oauth/token",
-      authorize = "https://wakatime.com/oauth/authorize",
-      base_url = "https://api.wakatime.com/api/v1"
-    ),
-    app = httr::oauth_app(
-      appname = "wakastudio",
-      key = app_id,
-      secret = app_secret
-    ),
-    scope = "read_stats"
+generate_oauth_token <- function(client_id = Sys.getenv("WAKATIME_ID"),
+                                 client_secret = Sys.getenv("WAKATIME_SECRET")) {
+  httr2::oauth_flow_client_credentials(
+    client = wakatime_client(client_id, client_secret),
+    scope = NULL,
+    token_params = list(
+      client_id = client_id,
+      client_secret = client_secret,
+      redirect_uri = "https://wakatime.com/oauth/authorize",
+      response_type = "token"
+    )
+  )
+
+  httr2::oauth_token(
+# INSERT TOKEN HERE
+    )
+
+}
+
+wakatime_client <- function(client_id, client_secret) {
+  httr2::oauth_client(
+    name = "wakatime",
+    id = client_id,
+    secret = client_secret,
+    token_url = "https://wakatime.com/oauth/token"
   )
 }

--- a/R/generate_oauth_token.R
+++ b/R/generate_oauth_token.R
@@ -1,35 +1,44 @@
 #' Generate a token for the WakaTime API
 #'
-#' @param client_id The app id for the WakaTime API
-#' @param client_secret The app secret for the WakaTime API
+#' @param client_id The app id for the WakaTime API. Defaults to the WAKATIME_ID
+#' environment variable.
+#' @param client_secret The app secret for the WakaTime API. Defaults to the
+#' WAKATIME_SECRET environment variable.
 #'
 #' @return An OAuth token
 #'
 #' @examples
+#' \dontrun{
+#' token <- generate_oauth_token()
+#'
+#' req <- request("https://api.wakatime.com/api/v1/users/current")
+#'
+#' req |>
+#'   req_oauth_auth_code(
+#'     client = wakatime_client(client_id, client_secret),
+#'     auth_url = "https://wakatime.com/oauth/authorize",
+#'     scope = "write_heartbeats",
+#'     redirect_uri = "https://wakatime.com/oauth/test"
+#'     ) |>
+#'   req_perform() |>
+#'   resp_body_json() |>
+#'   str()
+#' }
 generate_oauth_token <- function(client_id = Sys.getenv("WAKATIME_ID"),
                                  client_secret = Sys.getenv("WAKATIME_SECRET")) {
-  httr2::oauth_flow_client_credentials(
+  httr2::oauth_flow_auth_code(
     client = wakatime_client(client_id, client_secret),
+    auth_url = "https://wakatime.com/oauth/authorize",
     scope = NULL,
-    token_params = list(
-      client_id = client_id,
-      client_secret = client_secret,
-      redirect_uri = "https://wakatime.com/oauth/authorize",
-      response_type = "token"
-    )
+    redirect_uri = "https://wakatime.com/oauth/test"
   )
-
-  httr2::oauth_token(
-# INSERT TOKEN HERE
-    )
-
 }
 
 wakatime_client <- function(client_id, client_secret) {
   httr2::oauth_client(
-    name = "wakatime",
     id = client_id,
+    token_url = "https://wakatime.com/oauth/token",
     secret = client_secret,
-    token_url = "https://wakatime.com/oauth/token"
+    name = "wakatime"
   )
 }

--- a/tests/testthat/test-generate_oauth_token.R
+++ b/tests/testthat/test-generate_oauth_token.R
@@ -1,0 +1,8 @@
+# test_that("generate_oauth_token function returns a valid OAuth token", {
+#   token <- generate_oauth_token()
+#
+#   expect_is(token, "oauth_token")
+#   expect_true(!is.null(token$credentials$access_token))
+#   expect_true(!is.null(token$endpoint))
+#   expect_true(!is.null(token$app))
+# })


### PR DESCRIPTION
This PR adds a function to generate an OAuth token, using a Waktime App ID and Secret. 
See https://wakatime.com/apps to create a wakatime App (and get the appropriate ID and Secret)

See here for wakatime's API documentation, especially on authentication:
https://wakatime.com/developers/#authentication
and 

Relates to #8 